### PR TITLE
Remove commandline_splitter dependency.

### DIFF
--- a/lib/ogurets_flutter.dart
+++ b/lib/ogurets_flutter.dart
@@ -3,7 +3,6 @@ library ogurets_flutter;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:commandline_splitter/commandline_splitter.dart';
 import 'package:ogurets/ogurets.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import "package:logging/logging.dart";


### PR DESCRIPTION
Modified to fix #3 - commandline_splitter doesn't handle most of the flutter run arguments correctly due to the way it parses dashes.  Replaced with a parser that is the dart port of the one that Apache Ant uses. 

Also modified to catch and exit with flutter run non-zero exit codes so that it doesn't have to wait on the observatory timeout if there is an error.