### PR TITLE
Fix wait issue and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ class CounterStepdefs {
 }
 ```
 
+### vscode
+
+If you are using Visual Studio Code, you can debug the tests by adding a section like the following to your `launch.json`.  This is for the example solution in the repository.
+
+```json
+{
+            //Can't run this with the normal working directory because the Dart plugin helpfully tries to launch Flutter, and we 
+            //want to run it as dart. 
+            "name": "Debug E2E Tests",
+            "request": "launch",
+            "type": "dart",
+            "program": "ogurets_flutter_test.dart",
+            "cwd": "example/test_driver",
+            "env": {"OGURETS_FLUTTER_WORKDIR":"..", "OGURETS_FLUTTER_START_TIMEOUT":"120", "OGURETS_ADDITIONAL_ARGUMENTS":""},
+          }
+```
+The `ogurets_flutter_test.dart` file would have to be modified to look for features in that directory as well, since the launch configuration changes the cwd so that tests can be debugged.  Otherwise, the Dart Code plugin attempts to launch as a Flutter rather than Dart debugger.
+
+```dart
+    ..feature('test_driver/features/counter.feature')
+    ..feature('features')
+```
+
 ## environment variables
 
 If you wish to control the flutter run via your own command line build, then the important environment variables are

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ class CounterStepdefs {
 
 If you are using Visual Studio Code, you can debug the tests by adding a section like the following to your `launch.json`.  This is for the example solution in the repository.
 
-```json
+```jsonc
 {
             //Can't run this with the normal working directory because the Dart plugin helpfully tries to launch Flutter, and we 
             //want to run it as dart. 

--- a/lib/flutter_autorun.dart
+++ b/lib/flutter_autorun.dart
@@ -105,14 +105,7 @@ class FlutterRunProcessHandler {
            // Get the exit code of flutter run and stop if there is an error so we don't have to wait for the timeout
           exit(await _runningProcess.exitCode);
     }));
-
-    // Get the exit code of flutter run and stop if there is an error so we don't have to wait for the timeout
-    var exitCode = await _runningProcess.exitCode;
-
-    if(exitCode != 0)
-    {
-      exit(exitCode);
-    }
+    
   }
 
   // attempts to restart the running app

--- a/lib/flutter_autorun.dart
+++ b/lib/flutter_autorun.dart
@@ -96,18 +96,12 @@ class FlutterRunProcessHandler {
     _openSubscriptions.add(_processStdoutStream.listen((data) {
       stdout.writeln(">> " + data);
     }));
-    _openSubscriptions.add(_processStderrStream.listen((events) {
+    _openSubscriptions.add(_processStderrStream.listen((events) async {
       stderr
           .writeln(">> ${FAIL_COLOUR}Flutter run error: $events$RESET_COLOUR");
+           // Get the exit code of flutter run and stop if there is an error so we don't have to wait for the timeout
+          exit(await _runningProcess.exitCode);
     }));
-
-    // Get the exit code of flutter run and stop if there is an error so we don't have to wait for the timeout
-    var exitCode = await _runningProcess.exitCode;
-
-    if(exitCode != 0)
-    {
-      exit(exitCode);
-    }
   }
 
   // attempts to restart the running app

--- a/lib/flutter_autorun.dart
+++ b/lib/flutter_autorun.dart
@@ -60,6 +60,7 @@ class FlutterRunProcessHandler {
 
   DriverPlatform get platform => _platform;
 
+  /// builds the command line arguments for flutter run and calls startApp()
   Future<void> run() async {
     cmdLine = [
       "run",
@@ -83,6 +84,8 @@ class FlutterRunProcessHandler {
     await startApp();
   }
 
+  /// Calls flutter run with any additional arguments. Do not await anything that is not a critical error, or the tests
+  /// will not execute because it will wait for the process to exit.
   Future startApp() async {
     _log.info("flutter ${cmdLine.join(' ')}");
 
@@ -117,6 +120,7 @@ class FlutterRunProcessHandler {
     }
   }
 
+  /// close the running app
   Future<int> terminate() async {
     print("closing app.");
     int exitCode = -1;
@@ -133,7 +137,7 @@ class FlutterRunProcessHandler {
     return exitCode;
   }
 
-  //
+  /// wait for a specific message to appear in the console
   Future<String> waitForConsoleMessage(
       RegExp search, String timeoutException, String failMessage) {
     _ensureRunningProcess();
@@ -201,6 +205,7 @@ class FlutterRunProcessHandler {
     return completer.future;
   }
 
+  /// wait for the debugger uri - appears after flutter run has started
   Future<String> waitForObservatoryDebuggerUri() {
     return waitForConsoleMessage(
         _observatoryDebuggerUriRegex,
@@ -208,6 +213,7 @@ class FlutterRunProcessHandler {
         "${FAIL_COLOUR}No connected devices found to run app on and tests against$RESET_COLOUR");
   }
 
+  /// make sure flutter run is executing - _runningProcess is set by startApp()
   void _ensureRunningProcess() {
     if (_runningProcess == null) {
       throw Exception(
@@ -215,7 +221,7 @@ class FlutterRunProcessHandler {
     }
   }
 
-  ///Port of translateCommandline https://commons.apache.org/proper/commons-exec/apidocs/src-html/org/apache/commons/exec/CommandLine.html
+  /// port of translateCommandline https://commons.apache.org/proper/commons-exec/apidocs/src-html/org/apache/commons/exec/CommandLine.html
   List<String> _splitArgs(String line) {
     line = line.trimLeft();
 

--- a/lib/ogurets_flutter.dart
+++ b/lib/ogurets_flutter.dart
@@ -3,7 +3,6 @@ library ogurets_flutter;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:commandline_splitter/commandline_splitter.dart';
 import 'package:ogurets/ogurets.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import "package:logging/logging.dart";


### PR DESCRIPTION
Last commit didn't take flutter run into account, and broke the test runner by waiting for an exit code before moving on.  Moved the exit as async only when there is a flutter run error, added some additional comments to hopefully prevent the same in the future, and updated the readme to include how to run using vscode.